### PR TITLE
Set timestamp and frame_id for IMU data message

### DIFF
--- a/src/bno085/bno085/BNO085_pub.py
+++ b/src/bno085/bno085/BNO085_pub.py
@@ -67,6 +67,9 @@ class BNO085_Publisher(Node):
 
         #create messages to publish
         imu_data_msg = Imu()
+        # Set timestamp
+        imu_data_msg.header.stamp = self.get_clock().now().to_msg()
+        imu_data_msg.header.frame_id = "imu_link"
         robot_ori_euler_msg = Vector3()
 
         # TODO: Double check that this is true


### PR DESCRIPTION
Add header timestamp and frame_id to IMU messages

robot_localization ignores IMU messages without a valid header.stamp and header.frame_id. This change ensures compatibility by:

- Setting header.stamp using the node clock
- Adding configurable frame_id (default: imu_link)

This prevents IMU data from being silently dropped during EKF fusion.